### PR TITLE
Prevent TypeError when the page being inspected has no images.

### DIFF
--- a/output.js
+++ b/output.js
@@ -62,7 +62,7 @@ exports.init = function() {
         threshold = parameters.threshold || threshold;
         verbose = parameters.verbose;
 
-        var yourImageWeight = parseInt(response.pageStats.imageResponseBytes, 10);
+        var yourImageWeight = parseInt(response.pageStats.imageResponseBytes || 0, 10);
         var unoptimizedImages = response.formattedResults.ruleResults.OptimizeImages.urlBlocks;
         var shave = chalk.cyan("Thanks for keeping the web fast <3");
         var imagesToOptimize = "";


### PR DESCRIPTION
This simply sets the number to zero when no images are found. (E.g. Issue #4)

It's a pretty simplistic solution, but it definitely works. I didn't add a test but I'm happy to do so if you think it would be useful.

``` text
$ ./bin/cli.js http://brycebaril.com
Your image weight:
0 B
Average image weight on the web:
1.2 MB
Thanks for keeping the web fast <3
```
