### PR TITLE
Update dependencies: prepend-http and CSVparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   ],
   "dependencies": {
     "chalk": "^0.5.1",
+    "csv-parse": "0.0.6",
     "gpagespeed": "0.0.8",
     "minimist": "^1.1.0",
-    "pretty-bytes": "^1.0.1"
+    "pretty-bytes": "^1.0.1",
+    "prepend-http": "^1.0.0"
   },
   "devDependencies": {
-    "csv-parse": "0.0.6",
-    "mocha": "^2.0.1",
-    "prepend-http": "^1.0.0"
+    "mocha": "^2.0.1"
   }
 }


### PR DESCRIPTION
I've node v0.10.33 running using nvm on a OSX 10.10.1 machine and after installing it globally via `npm install -g tmi` I kept on getting this error.

```
vagrant@precise32:~$ npm install -g tmi
/home/vagrant/.nvm/v0.10.33/bin/tmi -> /home/vagrant/.nvm/v0.10.33/lib/node_modules/tmi/bin/cli.js
tmi@0.2.0 /home/vagrant/.nvm/v0.10.33/lib/node_modules/tmi
├── minimist@1.1.0
├── pretty-bytes@1.0.1 (get-stdin@1.0.0)
├── chalk@0.5.1 (escape-string-regexp@1.0.2, ansi-styles@1.1.0, supports-color@0.2.0, has-ansi@0.1.0, strip-ansi@0.3.0)
└── gpagespeed@0.0.8 (valid-url@1.0.9, minimist@0.2.0, googleapis@1.0.21)
vagrant@precise32:~$ tmi bassam.co

module.js:340
    throw err;
          ^
Error: Cannot find module 'prepend-http'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/vagrant/.nvm/v0.10.33/lib/node_modules/tmi/index.js:11:19)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

After digging a bit I found that the modules `prepend-http` and `csv-parse` were listed as dev dependencies and weren't getting installed without manually running `npm install` in the module directory.

Just to be sure I created a clean new vagrant box (precise32) and installed nvm, node v0.10.33 and tmi and still got the same error.  
I've moved them to dependencies hash now. 
